### PR TITLE
Fix bugs discovered while playing CTF

### DIFF
--- a/arch.py
+++ b/arch.py
@@ -146,7 +146,7 @@ def fuse_ops(data, addr, order):
             if isinstance(y.b, microblaze.Imm16):
                 y = copy.copy(y)  # ???
                 y.b = microblaze.Imm32(
-                    i=(x.b.i << 16) | (y.b.i),
+                    i=(x.b.i << 16) | (y.b.i & 0xFFFF),
                     fused_from=type(y.b)
                 )
                 # length is treated as 8 to fool assembler algorithm, but .addr

--- a/microblaze.py
+++ b/microblaze.py
@@ -486,7 +486,7 @@ class Bit(Op):
         else:
             one = il.const(1, 1)
             if self.op == 'SRL':
-                val = il.shift_left(4, a, one, flags='carry')
+                val = il.logical_shift_right(4, a, one, flags='carry')
             elif self.op == 'SRA':
                 val = il.arith_shift_right(4, a, one, flags='carry')
             elif self.op == 'SRC':

--- a/reloc.py
+++ b/reloc.py
@@ -205,7 +205,7 @@ class MicroBlazeELFRelocationHandler(CustomRelocationHandler):
                 reloc.truncateSize = 4
             elif reloc.nativeType == R_MICROBLAZE._COPY:
                 reloc.type = bn.RelocationType.ELFCopyRelocationType
-                reloc.pcRelative = false
+                reloc.pcRelative = False
                 reloc.baseRelative = False
                 reloc.size = 4
                 reloc.truncateSize = 4


### PR DESCRIPTION
Hi,

This weekend the Hack-A-Sat 2022 Quals CTF had a couple microblaze challenges, so I turned to this plugin to save myself the trouble of learning microblaze assembly.

Along the way, I noticed a couple bugs, so here's some potential fixes :) I believe they're correct but they're untested outside of analyzing CTF binaries.

BTW, the bitspec stuff looks pretty cool!

Thanks for the plugin!